### PR TITLE
Fix for #387 TypeError: process.stdin.end is not a function

### DIFF
--- a/packages/aws-cdk-v2/src/utils/executor.util.ts
+++ b/packages/aws-cdk-v2/src/utils/executor.util.ts
@@ -73,7 +73,9 @@ export function runCommandProcess(command: string, cwd: string): Promise<boolean
 
       process.removeListener('exit', processExitListener);
 
-      process.stdin.end();
+      if (process.stdin.end) {
+        process.stdin.end();
+      }
       process.stdin.removeListener('data', processExitListener);
     });
   });


### PR DESCRIPTION
# Description

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #387
