### PR TITLE
Check if stdin is a TTY before ending it

### DIFF
--- a/packages/aws-cdk-v2/src/utils/executor.util.ts
+++ b/packages/aws-cdk-v2/src/utils/executor.util.ts
@@ -73,7 +73,7 @@ export function runCommandProcess(command: string, cwd: string): Promise<boolean
 
       process.removeListener('exit', processExitListener);
 
-      if (process.stdin.end) {
+      if (process.stdin.isTTY) {
         process.stdin.end();
       }
       process.stdin.removeListener('data', processExitListener);


### PR DESCRIPTION
# Description
After testing on AWS CodeBuild, the issue with TypeError on `stdin.end()` persisted.
With some investigation, I found that a check for `stdin.isTTY` is the most appropriate check. [Reference 1](https://stackoverflow.com/questions/53049939/node-daemon-wont-start-with-process-stdin-setrawmodetrue), [Reference 2](https://nodejs.org/docs/latest-v16.x/api/tty.html#readstreamistty)

I was also able to test the fix with success on CodeBuild this time.

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #387
